### PR TITLE
Update Crazy Kong (Orca bootleg).mra

### DIFF
--- a/releases/Crazy Kong (Orca bootleg).mra
+++ b/releases/Crazy Kong (Orca bootleg).mra
@@ -1,16 +1,16 @@
 <misterromdescription>
   <name>Crazy Kong (Orca bootleg)</name>
-  <mameversion>0217</mameversion>
+  <mameversion>0220</mameversion>
   <setname>ckongo</setname>
   <year>1981</year>
   <manufacturer>bootleg (Orca)</manufacturer>
   <rbf>CrazyKong</rbf>
-  <rom index="0" zip="ckong.zip" md5="fa1d74555f5c450c4f22f6eea0b13f16" type="merged">
-    <part crc="8bfb4623" name="ckongo/o55a-1"/>
-    <part crc="9ae8089b" name="ckongo/o55a-2"/>
-    <part crc="e82b33c8" name="ckongo/o55a-3"/>
-    <part crc="f038f941" name="ckongo/o55a-4"/>
-    <part crc="5182db06" name="ckongo/o55a-5"/>
+  <rom index="0" zip="ckong.zip|ckongo.zip|bigkong.zip" md5="fa1d74555f5c450c4f22f6eea0b13f16" type="merged|split">
+    <part crc="8bfb4623" name="o55a-1"/>
+    <part crc="9ae8089b" name="o55a-2"/>
+    <part crc="e82b33c8" name="o55a-3"/>
+    <part crc="f038f941" name="o55a-4"/>
+    <part crc="5182db06" name="o55a-5"/>
     <part repeat="4096">00</part>
     <part repeat="4096">00</part>
     <part repeat="4096">00</part>
@@ -22,18 +22,18 @@
     <part repeat="4096">00</part>
     <part repeat="4096">00</part>
     <part repeat="4096">00</part>
-    <part crc="cae9e2bf" name="ckongo/o50b-1" offset="0" length="2048"/>
-    <part crc="fba82114" name="ckongo/o50b-2" offset="0" length="2048"/>
-    <part crc="cae9e2bf" name="ckongo/o50b-1" offset="2048" length="2048"/>
-    <part crc="fba82114" name="ckongo/o50b-2" offset="2048" length="2048"/>
-    <part crc="1714764b" name="ckongo/o50b-3" offset="0" length="2048"/>
-    <part crc="b7008b57" name="ckongo/o50b-4" offset="0" length="2048"/>
-    <part crc="1714764b" name="ckongo/o50b-3" offset="2048" length="2048"/>
-    <part crc="b7008b57" name="ckongo/o50b-4" offset="2048" length="2048"/>
-    <part crc="d1352c31" name="bigkong/c11-02.bin"/>
-    <part crc="a7a2fdbd" name="bigkong/a11-01.bin"/>
-    <part crc="d1352c31" name="bigkong/c11-02.bin"/>
-    <part crc="a7a2fdbd" name="bigkong/a11-01.bin"/>
+    <part crc="cae9e2bf" name="o50b-1" offset="0" length="2048"/>
+    <part crc="fba82114" name="o50b-2" offset="0" length="2048"/>
+    <part crc="cae9e2bf" name="o50b-1" offset="2048" length="2048"/>
+    <part crc="fba82114" name="o50b-2" offset="2048" length="2048"/>
+    <part crc="1714764b" name="o50b-3" offset="0" length="2048"/>
+    <part crc="b7008b57" name="o50b-4" offset="0" length="2048"/>
+    <part crc="1714764b" name="o50b-3" offset="2048" length="2048"/>
+    <part crc="b7008b57" name="o50b-4" offset="2048" length="2048"/>
+    <part crc="d1352c31" name="c11-02.bin"/>
+    <part crc="a7a2fdbd" name="a11-01.bin"/>
+    <part crc="d1352c31" name="c11-02.bin"/>
+    <part crc="a7a2fdbd" name="a11-01.bin"/>
     <part crc="5f0bcdfb" name="falcon13"/>
     <part crc="9003ffbd" name="falcon12"/>
   </rom>


### PR DESCRIPTION
Now works with split set. Should also work with non-merged set (untested). The reference to bigkong.zip is left as failsafe, at least in .220 set, files c11-02.bin and a11-01.bin exist also in ckongo.zip, and they have the same CRC.