### PR TITLE
Create Crazy Kong

### DIFF
--- a/releases/Crazy Kong
+++ b/releases/Crazy Kong
@@ -1,0 +1,38 @@
+<misterromdescription>
+	<name>Crazy Kong</name>
+	<mameversion>0224</mameversion>
+	<setname>ckong</setname>
+	<year>1981</year>
+	<manufacturer>Kyoei / Falcon</manufacturer>
+	<category>Maze / Monkeys</category>
+	<category>Platform</category>
+	<category>Platform / Mario Bros.</category>
+	<rbf>CrazyKong</rbf>
+	<buttons names="Jump,Start 1P,Start 2P,Coin" default="A,Start,Select,R"/>
+	<rom index="0" zip="ckong.zip" md5="97793b507edf1529355e900a01dd0e5a" type="merged|nonmerged|split">
+		<!-- maincpu -->
+		<part crc="2171cac3" name="falcon7"/>
+		<part crc="88b83ff7" name="falcon8"/>
+		<part crc="cff2af47" name="falcon9"/>
+		<part crc="6b2ecf23" name="falcon10"/>
+		<part crc="327dcadf" name="falcon11"/>
+		<part repeat="45056">00</part>
+		<!-- gfx1 -->
+		<part crc="a8916dc8" name="falcon6"/>
+		<part crc="cd3b5dde" name="falcon5"/>
+		<part crc="b62a0367" name="falcon4"/>
+		<part crc="61122c5e" name="falcon3"/>
+		<!-- gfx2 -->
+		<part crc="f67c80f1" name="falcon2"/>
+		<part crc="80eb517d" name="falcon1"/>
+		<part crc="f67c80f1" name="falcon2"/>
+		<part crc="80eb517d" name="falcon1"/>
+		<!-- cclimber_audio:samples -->
+		<part crc="5f0bcdfb" name="falcon13"/>
+		<part crc="9003ffbd" name="falcon12"/>
+		<!-- proms -->
+		<part crc="751c3325" name="ck6v.bin"/>
+		<part crc="ab1940fa" name="ck6u.bin"/>
+		<part crc="b4e827a5" name="ck6t.bin"/>
+	</rom>
+</misterromdescription>


### PR DESCRIPTION
This is the first release of Crazy Kong. It has a few differences from Crazy Kong Part II:
- different colours
- no intro showing Crazy Kong breaking off his cage
- the top left hammer in the barrel stage is easier to grab
- no gaps in girders of the barrel stage, even on higher levels
- Mario can walk behind Crazy Kong in the rivet stage
- no give up message after Crazy Kong is defeated
- no item pickup sounds